### PR TITLE
Simplified the connection code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a intuitive [Game Maker Studio: 2](https://www.yoyogames.com/gamemaker) 
 # Installation
 * Import this extension
 * Done! 
-You don't need any objects which initializes the extension or anything else. Just call `sio_connect(ip:string, port:int)` in order to connect to the server, that's all! :)
+You don't need any objects which initializes the extension or anything else. Just call `sio_connect()` in order to connect to the server, that's all! :)
 
 I recommend you to check out the [Example project](https://github.com/IgnasKavaliauskas/SocketIO-GMS2-Extension/tree/master/Example) to get started.
 

--- a/Source/gms2.api.js
+++ b/Source/gms2.api.js
@@ -2,8 +2,7 @@
     Gamemaker: Studio 2 Socket.io extension 
     Author:         Ignas Kavaliauskas (Inspired by Ivan Fonseca)
     Edited By:      Chan Pei Keong (Inspired by Ignas Kavaliauskas)
-    Forked From:    https://github.com/IgnasKavaliauskas/SocketIO-GMS2-Extension
-    Source:         https://github.com/Nichii/SocketIO-GMS2-Extension
+    Source:         https://github.com/IgnasKavaliauskas/SocketIO-GMS2-Extension
 */
 
 // Small wrapper of Socket.io for GM:S 2

--- a/Source/gms2.api.js
+++ b/Source/gms2.api.js
@@ -14,14 +14,12 @@ class SocketIO {
 
     connect() {
         this.socket = io();
+        this.initSocketEvent();
+    }
 
-        this.socket.on('connect', () => {
-            gml_Script_gmcallback_sio_on_connect();
-        });
-
-        this.socket.on('disconnect', () => {
-            gml_Script_gmcallback_sio_on_disconnect();
-        });
+    connectByUrl(url) {
+        this.socket = io(url);
+        this.initSocketEvent();
     }
 
     disconnect() {
@@ -30,6 +28,16 @@ class SocketIO {
 
     reconnect() {
         this.socket.open();
+    }
+
+    initSocketEvent() {
+        this.socket.on('connect', () => {
+            gml_Script_gmcallback_sio_on_connect();
+        });
+
+        this.socket.on('disconnect', () => {
+            gml_Script_gmcallback_sio_on_disconnect();
+        });
     }
 
     addEvent(name) {
@@ -55,6 +63,10 @@ const socketio = new SocketIO();
 
 function sio_connect() {
     socketio.connect();
+}
+
+function sio_connect_by_url(url) {
+    socketio.connectByUrl(url);
 }
 
 function sio_disconnect() {

--- a/Source/gms2.api.js
+++ b/Source/gms2.api.js
@@ -37,12 +37,12 @@ class SocketIO {
             if (typeof data === 'object')
                 data = JSON.stringify(data);
 
-            window[`gml_Script_gmcallback_sio_on_${name.toLowerCase()}`](-1, -1, data);
+            window[`gml_Script_gmcallback_sio_on_${name}`](-1, -1, data);
         });
     }
 
     send(name, data) {
-        this.socket.emit(name.toLowerCase(), data);
+        this.socket.emit(name, data);
     }
 
     getConnectionStatus() {

--- a/Source/gms2.api.js
+++ b/Source/gms2.api.js
@@ -1,7 +1,9 @@
 /*
     Gamemaker: Studio 2 Socket.io extension 
-    Author: Ignas Kavaliauskas (Inspired by Ivan Fonseca)
-    https://github.com/IgnasKavaliauskas/SocketIO-GMS2-Extension
+    Author:         Ignas Kavaliauskas (Inspired by Ivan Fonseca)
+    Edited By:      Chan Pei Keong (Inspired by Ignas Kavaliauskas)
+    Forked From:    https://github.com/IgnasKavaliauskas/SocketIO-GMS2-Extension
+    Source:         https://github.com/Nichii/SocketIO-GMS2-Extension
 */
 
 // Small wrapper of Socket.io for GM:S 2
@@ -9,15 +11,10 @@ class SocketIO {
 
     constructor() {
         this.socket;
-        this.ip;
-        this.port;
     }
 
-    connect(ip, port) {
-        this.ip = ip;
-        this.port = port;
-
-        this.socket = io.connect(`http://${this.ip}:${this.port}`);
+    connect() {
+        this.socket = io();
 
         this.socket.on('connect', () => {
             gml_Script_gmcallback_sio_on_connect();
@@ -57,8 +54,8 @@ class SocketIO {
 // API for GM:S 2
 const socketio = new SocketIO();
 
-function sio_connect(ip, port) {
-    socketio.connect(ip, port);
+function sio_connect() {
+    socketio.connect();
 }
 
 function sio_disconnect() {


### PR DESCRIPTION
Client socket.io connection can be made to the server just by calling the 'io();' function. Source: https://socket.io/docs/client-api/

Stated in url parameter for 'io([url][, options]);' function:
- url (String) (defaults to window.location)

The above replaces the 'io.connect(`http://${ip}:${port}`)' which makes it impossible to connect to the server if your URL doesn't follow the same template.

In addition to that, I have added the ability to connect by a specific URL (if your server is hosted elsewhere) with a new function called sio_connect_by_url(url: string) and removed the lowercase event name restriction.

This may cause minor rewrites required from the Wiki, examples and GMS/GMS2's extension.